### PR TITLE
Fix some memory lack

### DIFF
--- a/incomingstream.go
+++ b/incomingstream.go
@@ -323,4 +323,5 @@ func (i *IncomingStream) Stop() {
 	}
 
 	native.DeleteRTPReceiverFacade(i.receiver) // other module maybe need delete
+	i.receiver = nil
 }

--- a/incomingstream.go
+++ b/incomingstream.go
@@ -322,4 +322,5 @@ func (i *IncomingStream) Stop() {
 		stopFunc()
 	}
 
+	native.DeleteRTPReceiverFacade(i.receiver) // other module maybe need delete
 }

--- a/incomingstreamtrack.go
+++ b/incomingstreamtrack.go
@@ -496,14 +496,7 @@ func (i *IncomingStreamTrack) Stop() {
 	if i.receiver == nil {
 		return
 	}
-
-	for _, encoding := range i.encodings {
-		if encoding.depacketizer != nil {
-			encoding.depacketizer.Stop()
-			native.DeleteStreamTrackDepacketizer(encoding.depacketizer)
-		}
-	}
-
+	
 	if i.mediaframeMultiplexer != nil {
 		i.mediaframeMultiplexer.Stop()
 		i.mediaframeMultiplexer = nil
@@ -511,6 +504,16 @@ func (i *IncomingStreamTrack) Stop() {
 
 	for _, stopFunc := range i.onStopListeners {
 		stopFunc()
+	}
+
+	for _, encoding := range i.encodings {
+		if encoding.depacketizer != nil {
+			encoding.depacketizer.Stop()
+			native.DeleteStreamTrackDepacketizer(encoding.depacketizer)
+		}
+		if encoding.source != nil {
+			native.DeleteRTPIncomingSourceGroup(encoding.source)
+		}
 	}
 
 	i.encodings = nil

--- a/outgoingstreamtrack.go
+++ b/outgoingstreamtrack.go
@@ -257,6 +257,7 @@ func (o *OutgoingStreamTrack) Stop() {
 
 	o.source = nil
 
+	native.DeleteRTPSenderFacade(o.sender)
 	o.sender = nil
 }
 

--- a/outgoingstreamtrack.go
+++ b/outgoingstreamtrack.go
@@ -242,7 +242,10 @@ func (o *OutgoingStreamTrack) Stop() {
 	// swig memory clean
 	o.interCallback.deleteREMBBitrateListener()
 
-	o.transpoder.Stop()
+	if o.transpoder != nil { // maybe = nil at onTransponderStopped
+		o.transpoder.Stop()
+		o.transpoder = nil
+	}
 
 	for _, stopFunc := range o.onStopListeners {
 		stopFunc()


### PR DESCRIPTION
==19920== 8 bytes in 1 blocks are definitely lost in loss record 7 of 601
==19920==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19920==    by 0xB6B65D: TransportToSender(DTLSICETransport*) (mediaserver_wrap.cxx:862)
==19920==    by 0xB6A426: _cgo_b9c3ecf42ab9_Cfunc__wrap_TransportToSender_native_4b7afac4175a7297 (cgo-gcc-prolog:6116)
==19920==    by 0x63AA1F: runtime.asmcgocall (/home/sp/Develop/go/src/runtime/asm_amd64.s:635)
==19920==    by 0x63725B: runtime.(*mheap).alloc.func1 (/home/sp/Develop/go/src/runtime/mheap.go:1048)
==19920==    by 0x639245: runtime.systemstack (/home/sp/Develop/go/src/runtime/asm_amd64.s:351)
==19920==    by 0x610C3F: ??? (/home/sp/Develop/go/src/runtime/proc.go:1082)
==19920==    by 0x6390D8: runtime.rt0_go (/home/sp/Develop/go/src/runtime/asm_amd64.s:201)
==19920==    by 0xE58B1F: ??? (in /home/sp/Develop/go-work/src/100tal/rtcengine_media_server/run-bj/run-bj)
==19920==    by 0x6390DF: runtime.rt0_go (/home/sp/Develop/go/src/runtime/asm_amd64.s:206)### ###

==19920== 8 bytes in 1 blocks are definitely lost in loss record 9 of 601
==19920==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19920==    by 0xB6B67D: TransportToReceiver(DTLSICETransport*) (mediaserver_wrap.cxx:866)
==19920==    by 0xB6A3F6: _cgo_b9c3ecf42ab9_Cfunc__wrap_TransportToReceiver_native_4b7afac4175a7297 (cgo-gcc-prolog:6098)
==19920==    by 0x63AA1F: runtime.asmcgocall (/home/sp/Develop/go/src/runtime/asm_amd64.s:635)
==19920==    by 0x63725B: runtime.(*mheap).alloc.func1 (/home/sp/Develop/go/src/runtime/mheap.go:1048)
==19920==    by 0x639245: runtime.systemstack (/home/sp/Develop/go/src/runtime/asm_amd64.s:351)
==19920==    by 0x610C3F: ??? (/home/sp/Develop/go/src/runtime/proc.go:1082)
==19920==    by 0x6390D8: runtime.rt0_go (/home/sp/Develop/go/src/runtime/asm_amd64.s:201)
==19920==    by 0xE58B1F: ??? (in /home/sp/Develop/go-work/src/100tal/rtcengine_media_server/run-bj/run-bj)
==19920==    by 0x6390DF: runtime.rt0_go (/home/sp/Develop/go/src/runtime/asm_amd64.s:206)


==19920== 4,392 (1,712 direct, 2,680 indirect) bytes in 1 blocks are definitely lost in loss record 576 of 601
==19920==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==19920==    by 0xB6D223: _wrap_new_RTPIncomingSourceGroup_native_4b7afac4175a7297 (mediaserver_wrap.cxx:4456)
==19920==    by 0xB6AE3A: _cgo_b9c3ecf42ab9_Cfunc__wrap_new_RTPIncomingSourceGroup_native_4b7afac4175a7297 (cgo-gcc-prolog:7342)
==19920==    by 0x63AA1F: runtime.asmcgocall (/home/sp/Develop/go/src/runtime/asm_amd64.s:635)
==19920==    by 0x2F: ???
 